### PR TITLE
Better logic for .my.cnf creation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -155,10 +155,10 @@ class galera(
     $my_cnf = "[client]\r\nuser=root\r\nhost=localhost\r\npassword='${root_password}'\r\n"
 
     exec { "create ${::root_home}/.my.cnf":
-      command => "/bin/echo -e \"$my_cnf\" > ${::root_home}/.my.cnf",
+      command => "/bin/echo -e \"${my_cnf}\" > ${::root_home}/.my.cnf",
       onlyif  => [
         "/usr/bin/mysql --user=root --password=${root_password} -e 'select count(1);'",
-        "/usr/bin/test `/bin/cat ${::root_home}/.my.cnf | /bin/grep -c \"password='$root_password'\"` -eq 0",
+        "/usr/bin/test `/bin/cat ${::root_home}/.my.cnf | /bin/grep -c \"password='${root_password}'\"` -eq 0",
         ],
       require => [Service['mysqld']],
       before  => [Class['mysql::server::root_password']],


### PR DESCRIPTION
What we currently use: CSCfi/puppet-galera/centos7 forked from upstream fraenki/puppet-galera commit dc8657385a328d381b92bfe4c944211e08b5459b

Proposal to use: CSCfi/puppet-galera/centos7-mycnf-fix rebased to upstream fraenki/puppet-galera commit 94db13ce89a012e96be528c95580ee8d1aee56d5 , in other words 2 commits newer in upstream master.