### PR TITLE
Baseurl has been changed

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -41,7 +41,7 @@ class galera::repo(
 
   if ! $yum_mariadb_baseurl {
     $lower = downcase($::operatingsystem)
-    $real_yum_mariadb_baseurl = "http://yum.mariadb.org/5.5/${lower}${::operatingsystemmajrelease}-amd64/"
+    $real_yum_mariadb_baseurl = "http://yum.mariadb.org/5.5.65/${lower}${::operatingsystemmajrelease}-amd64/"
   } else {
     $real_yum_mariadb_baseurl = $yum_mariadb_baseurl
   }


### PR DESCRIPTION
We need to change baseurl of the mariadb repo as MariaDB-galera-server is not in specified url.

I have changed base url "http://yum.mariadb.org/5.5.65/centos7-amd64/" to "http://yum.mariadb.org/5.5.65/centos7-amd64/" to install "MariaDB-Galera-server".

Tested on pouta-backend-devel3.csc.fi and found installed MariaDB-Galera-server.