### PR TITLE
Use MariaDB archive instead of main yum repo

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,7 +26,9 @@ class galera::params {
     }
     elsif $galera::vendor_type == 'mariadb' {
       $mysql_service_name = 'mysql'
-      $mysql_package_name_internal = 'MariaDB-Galera-server'
+      # HACK CCCP-3224
+      #$mysql_package_name_internal = 'MariaDB-Galera-server'
+      $mysql_package_name_internal = 'MariaDB-server'
       $galera_package_name_internal = 'galera'
       $client_package_name_internal = 'MariaDB-client'
       $libgalera_location = '/usr/lib64/galera/libgalera_smm.so'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,9 +26,7 @@ class galera::params {
     }
     elsif $galera::vendor_type == 'mariadb' {
       $mysql_service_name = 'mysql'
-      # HACK CCCP-3224
-      #$mysql_package_name_internal = 'MariaDB-Galera-server'
-      $mysql_package_name_internal = 'MariaDB-server'
+      $mysql_package_name_internal = 'MariaDB-Galera-server'
       $galera_package_name_internal = 'galera'
       $client_package_name_internal = 'MariaDB-client'
       $libgalera_location = '/usr/lib64/galera/libgalera_smm.so'

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -41,7 +41,7 @@ class galera::repo(
 
   if ! $yum_mariadb_baseurl {
     $lower = downcase($::operatingsystem)
-    $real_yum_mariadb_baseurl = "http://yum.mariadb.org/5.5.65/${lower}${::operatingsystemmajrelease}-amd64/"
+    $real_yum_mariadb_baseurl = "http://archive.mariadb.org/mariadb-5.5.65/yum/${lower}${::operatingsystemmajrelease}-amd64/"
   } else {
     $real_yum_mariadb_baseurl = $yum_mariadb_baseurl
   }


### PR DESCRIPTION
5.5.65 has been removed from their main repo. The archive still has a copy that seems to work. Basically "one more hack" until we've upgraded to 10 series.