### PR TITLE
Disable module_hotfixes as this doesnt work currently

### DIFF
--- a/data/RedHat-8-family.yaml
+++ b/data/RedHat-8-family.yaml
@@ -4,4 +4,4 @@
 # AppStream repo because dnf gives preference to modular packages.
 galera::repo::mariadb::yum:
   priority: 1
-  module_hotfixes: 1
+#  module_hotfixes: 1

--- a/data/RedHat-8-family.yaml
+++ b/data/RedHat-8-family.yaml
@@ -4,4 +4,3 @@
 # AppStream repo because dnf gives preference to modular packages.
 galera::repo::mariadb::yum:
   priority: 1
-#  module_hotfixes: 1

--- a/lib/facter/os_name_lc.rb
+++ b/lib/facter/os_name_lc.rb
@@ -1,13 +1,13 @@
 Facter.add(:os_name_lc) do
   setcode do
-      bad_os = Facter.value(:os)['name'].downcase
-      case bad_os
-      when /redhat/
+    bad_os = Facter.value(:os)['name'].downcase
+    case bad_os
+    when /redhat/
       'almalinux'
-     when /centos/
-    'centos'
-      else
-       bad_os
+    when /centos/
+      'centos'
+    else
+      bad_os
     end
   end
 end

--- a/lib/facter/os_name_lc.rb
+++ b/lib/facter/os_name_lc.rb
@@ -1,7 +1,13 @@
 Facter.add(:os_name_lc) do
   setcode do
-    unless Facter.value(:os).nil?
-      Facter.value(:os)['name'].downcase
+      bad_os = Facter.value(:os)['name'].downcase
+      case bad_os
+      when /redhat/
+      'almalinux'
+     when /centos/
+    'centos'
+      else
+       bad_os
     end
   end
 end


### PR DESCRIPTION
Also Allow that redhat is replaced with almalinux to allow our servers to get the correct dirstribution for installing packages.

Basically if the os.name is redhat, it gets almalinux, if its centos it stays centos. 

